### PR TITLE
Add a stand-alone tool to push a model from disk

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+# ---------------------------------
+# Project Constants.
+# ---------------------------------
+
+# The validator WANDB project.
+WANDB_PROJECT = "pretraining-subnet"
+# The uid for this subnet.
+SUBNET_UID = 9
+# The root directory of this project.
+ROOT_DIR = Path(__file__).parent.parent
+# The maximum bytes for the hugging face repo (1 Gigabyte).
+MAX_HUGGING_FACE_BYTES = 1 * 1024 * 1024 * 1024
+# The maximum parameter size allowed for models.
+MAX_MODEL_PARAMETER_SIZE = 122268040
+
+# ---------------------------------
+# Miner/Validator Model parameters.
+# ---------------------------------
+
+weights_version_key = 2002
+
+# validator weight moving average term
+alpha = 0.9
+# validator scoring exponential temperature
+temperature = 0.25
+# validator score boosting for earlier models.
+timestamp_epsilon = 0.01
+# validators number of pages to eval over miners on each step.
+n_eval_pages = 3
+# validator eval batch size.
+batch_size = 1
+# validator eval sequence length.
+sequence_length = 1024

--- a/model/model_updater.py
+++ b/model/model_updater.py
@@ -1,6 +1,6 @@
 import bittensor as bt
 from typing import Optional
-import pretrain
+import constants
 from model.data import ModelMetadata
 from model.model_tracker import ModelTracker
 from model.storage.local_model_store import LocalModelStore
@@ -57,9 +57,9 @@ class ModelUpdater:
 
         # Check that the parameter count of the model is within allowed bounds.
         parameter_size = sum(p.numel() for p in model.pt_model.parameters())
-        if parameter_size > pretrain.MAX_MODEL_PARAMETER_SIZE:
+        if parameter_size > constants.MAX_MODEL_PARAMETER_SIZE:
             raise ValueError(
-                f"Sync for hotkey {hotkey} failed. Parameter size of the model {parameter_size} exceeded max size {pretrain.MAX_MODEL_PARAMETER_SIZE}."
+                f"Sync for hotkey {hotkey} failed. Parameter size of the model {parameter_size} exceeded max size {constants.MAX_MODEL_PARAMETER_SIZE}."
             )
 
         # Update the tracker

--- a/model/storage/chain/chain_model_metadata_store.py
+++ b/model/storage/chain/chain_model_metadata_store.py
@@ -3,7 +3,7 @@ import functools
 import bittensor as bt
 import os
 from model.data import ModelId, ModelMetadata
-import pretrain as pt
+import constants
 from model.storage.model_metadata_store import ModelMetadataStore
 from typing import Optional
 
@@ -17,7 +17,7 @@ class ChainModelMetadataStore(ModelMetadataStore):
         self,
         subtensor: bt.subtensor,
         wallet: Optional[bt.wallet] = None,
-        subnet_uid: int = pt.SUBNET_UID,
+        subnet_uid: int = constants.SUBNET_UID,
     ):
         self.subtensor = subtensor
         self.wallet = (

--- a/model/storage/hugging_face/test_hugging_face_model_store.py
+++ b/model/storage/hugging_face/test_hugging_face_model_store.py
@@ -1,0 +1,82 @@
+import asyncio
+import os
+from model.data import Model, ModelId
+from model.storage.disk import utils
+from model.storage.hugging_face.hugging_face_model_store import HuggingFaceModelStore
+
+from pretrain.model import get_model
+
+
+async def test_roundtrip_model():
+    """Verifies that the HuggingFaceModelStore can roundtrip a model in hugging face."""
+    hf_name = os.getenv("HF_NAME")
+    model_id = ModelId(
+        namespace=hf_name,
+        name="TestModel",
+    )
+
+    pt_model = get_model()
+
+    model = Model(id=model_id, pt_model=pt_model)
+    hf_model_store = HuggingFaceModelStore()
+
+    # Store the model in hf getting back the id with commit and hash.
+    model.id = await hf_model_store.upload_model(model)
+
+    # Retrieve the model from hf.
+    retrieved_model = await hf_model_store.download_model(
+        model_id=model.id,
+        local_path=utils.get_local_miner_dir("test-models", "hotkey0"),
+    )
+
+    # Check that they match.
+    # TODO create appropriate equality check.
+    print(
+        f"Finished the roundtrip and checking that the models match: {str(model) == str(retrieved_model)}"
+    )
+
+
+async def test_retrieve_model():
+    """Verifies that the HuggingFaceModelStore can retrieve a model."""
+    model_id = ModelId(
+        namespace="pszemraj",
+        name="distilgpt2-HC3",
+        hash="TestHash1",
+        commit="6f9ad47",
+    )
+
+    hf_model_store = HuggingFaceModelStore()
+
+    # Retrieve the model from hf (first run) or cache.
+    model = await hf_model_store.download_model(
+        model_id=model_id,
+        local_path=utils.get_local_miner_dir("test-models", "hotkey0"),
+    )
+
+    print(f"Finished retrieving the model with id: {model.id}")
+
+
+async def test_retrieve_oversized_model():
+    """Verifies that the HuggingFaceModelStore can raise an exception if the model is too big."""
+    model_id = ModelId(
+        namespace="microsoft",
+        name="phi-2",
+        hash="TestHash1",
+        commit="d318676",
+    )
+
+    hf_model_store = HuggingFaceModelStore()
+
+    try:
+        model = await hf_model_store.download_model(
+            model_id=model_id,
+            local_path=utils.get_local_miner_dir("test-models", "hotkey0"),
+        )
+    except ValueError as ve:
+        print(f"Caught expected exception for downloading too large of a model: {ve}")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_retrieve_model())
+    asyncio.run(test_roundtrip_model())
+    asyncio.run(test_retrieve_oversized_model())

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -29,6 +29,7 @@ import asyncio
 import argparse
 
 import wandb
+import constants
 from model.model_tracker import ModelTracker
 from model.model_updater import ModelUpdater
 from model.storage.chain.chain_model_metadata_store import ChainModelMetadataStore
@@ -102,13 +103,13 @@ class Validator:
         )
         parser.add_argument(
             "--model_dir",
-            default=os.path.join(pt.ROOT_DIR, "model-store/"),
+            default=os.path.join(constants.ROOT_DIR, "model-store/"),
             help="Where to store downloaded models",
         )
         parser.add_argument(
             "--netuid",
             type=str,
-            default=pt.SUBNET_UID,
+            default=constants.SUBNET_UID,
             help="The subnet UID.",
         )
 
@@ -378,7 +379,7 @@ class Validator:
                     uids=self.metagraph.uids,
                     weights=self.weights,
                     wait_for_inclusion=False,
-                    version_key=pt.weights_version_key,
+                    version_key=constants.weights_version_key,
                 )
             except:
                 pass
@@ -465,8 +466,8 @@ class Validator:
         ]
         batches = list(
             pt.dataset.SubsetFalconLoader(
-                batch_size=pt.batch_size,
-                sequence_length=pt.sequence_length,
+                batch_size=constants.batch_size,
+                sequence_length=constants.sequence_length,
                 pages=pages,
             )
         )
@@ -518,7 +519,7 @@ class Validator:
         model_weights = torch.tensor(
             [win_rate[uid] for uid in uids], dtype=torch.float32
         )
-        step_weights = torch.softmax(model_weights / pt.temperature, dim=0)
+        step_weights = torch.softmax(model_weights / constants.temperature, dim=0)
         bt.logging.success(f"Computed model wins : {wins}")
 
         # Update weights based on moving average.
@@ -526,7 +527,9 @@ class Validator:
         for i, uid_i in enumerate(uids):
             new_weights[uid_i] = step_weights[i]
         new_weights /= new_weights.sum()
-        self.weights = pt.alpha * self.weights + (1 - pt.alpha) * new_weights
+        self.weights = (
+            constants.alpha * self.weights + (1 - constants.alpha) * new_weights
+        )
         self.weights = self.weights.nan_to_num(0.0)
 
         # Filter based on win rate removing all by the sample_min best models for evaluation.

--- a/pretrain/__init__.py
+++ b/pretrain/__init__.py
@@ -1,7 +1,5 @@
 # The MIT License (MIT)
 # Copyright © 2023 Yuma Rao
-# TODO(developer): Set your name
-# Copyright © 2023 <your name>
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation
@@ -18,7 +16,6 @@
 # DEALINGS IN THE SOFTWARE.
 
 __version__ = "2.1.0"
-from pathlib import Path
 
 
 version_split = __version__.split(".")
@@ -27,32 +24,6 @@ __spec_version__ = (
     + (10 * int(version_split[1]))
     + (1 * int(version_split[2]))
 )
-weights_version_key = 2002
-
-# validator weight moving average term
-alpha = 0.9
-# validator scoring exponential temperature
-temperature = 0.25
-# validator update model timeout (time between checking uids)
-update_model_timeout = 2  # 2 = checks all models every 256 * 2 seconds.
-# validator score boosting for earlier models.
-timestamp_epsilon = 0.01
-# validators number of pages to eval over miners on each step.
-n_eval_pages = 3
-# validator eval batch size.
-batch_size = 1
-# validator eval sequence length.
-sequence_length = 1024
-# The validator WANDB project.
-WANDB_PROJECT = "pretraining-subnet"
-# The uid for this subnet.
-SUBNET_UID = 9
-# The root directory of this project.
-ROOT_DIR = Path(__file__).parent.parent
-# The maximum bytes for the hugging face repo (1 Gigabyte).
-MAX_HUGGING_FACE_BYTES = 1 * 1024 * 1024 * 1024
-# The maximum parameter size allowed for models.
-MAX_MODEL_PARAMETER_SIZE = 122268040
 
 from . import dataset
 from . import graph

--- a/pretrain/graph.py
+++ b/pretrain/graph.py
@@ -22,6 +22,7 @@ import json
 import wandb
 import torch
 import typing
+import constants
 import pretrain
 import bittensor as bt
 from datetime import datetime
@@ -31,13 +32,13 @@ from safetensors.torch import load_model, save_model
 
 def best_uid(metagraph: typing.Optional[bt.metagraph] = None):
     if not metagraph:
-        metagraph = bt.subtensor().metagraph(pretrain.SUBNET_UID)
+        metagraph = bt.subtensor().metagraph(constants.SUBNET_UID)
     return max(range(256), key=lambda uid: metagraph.I[uid].item())
 
 
 def best_model(metagraph: typing.Optional[bt.metagraph] = None, device: str = "cpu "):
     if not metagraph:
-        metagraph = bt.subtensor().metagraph(pretrain.SUBNET_UID)
+        metagraph = bt.subtensor().metagraph(constants.SUBNET_UID)
     _best_uid = best_uid(metagraph)
     sync(_best_uid, metagraph=metagraph)
     return model(_best_uid, device=device)
@@ -58,9 +59,7 @@ def timestamp(uid: int) -> typing.Optional[int]:
 def run(uid: int) -> typing.Optional["wandb.run"]:
     try:
         api = wandb.Api(timeout=100)
-        run = api.run(
-            f"opentensor-dev/{pretrain.WANDB_PROJECT}/{metadata(uid)['runid']}"
-        )
+        run = api.run(f"opentensor-dev/{constants.WANDB_PROJECT}/{metadata(uid)['runid']}")
         return run
     except Exception as e:
         bt.logging.debug(
@@ -440,7 +439,7 @@ def check_run_exists(uid, metadata: dict, metagraph):
     try:
         expected_runid = metadata["runid"]
         api = wandb.Api(timeout=100)
-        run = api.run(f"opentensor-dev/{pretrain.WANDB_PROJECT}/{expected_runid}")
+        run = api.run(f"opentensor-dev/{constants.WANDB_PROJECT}/{expected_runid}")
         assert run.config["uid"] == uid
         assert run.config["hotkey"] == metagraph.hotkeys[uid]
         return True
@@ -476,7 +475,7 @@ def get_run_for_uid(
 
     # Retrieve runs from the wandb project for this uid
     runs = api.runs(
-        f"opentensor-dev/{pretrain.WANDB_PROJECT}",
+        f"opentensor-dev/{constants.WANDB_PROJECT}",
         filters={
             "config.version": pretrain.__version__,
             "config.type": "miner",

--- a/pretrain/validation.py
+++ b/pretrain/validation.py
@@ -21,7 +21,7 @@
 import math
 import torch
 import typing
-import pretrain
+import constants
 import traceback
 import bittensor as bt
 
@@ -39,8 +39,8 @@ def iswin(loss_i, loss_j, block_i, block_j):
         bool: True if loss i is better, False otherwise.
     """
     # Adjust loss based on timestamp and pretrain epsilon
-    loss_i = (1 - pretrain.timestamp_epsilon) * loss_i if block_i < block_j else loss_i
-    loss_j = (1 - pretrain.timestamp_epsilon) * loss_j if block_j < block_i else loss_j
+    loss_i = (1 - constants.timestamp_epsilon) * loss_i if block_i < block_j else loss_i
+    loss_j = (1 - constants.timestamp_epsilon) * loss_j if block_j < block_i else loss_j
     return loss_i < loss_j
 
 

--- a/tools/clean_runs.py
+++ b/tools/clean_runs.py
@@ -1,5 +1,6 @@
 import wandb
 import bittensor as bt
+import constants
 import pretrain as pt
 from tqdm import tqdm
 
@@ -15,7 +16,7 @@ for uid in metagraph.uids.tolist():
     bt.logging.success(f"Got valid run: {valid_run_id}")
 
     all_uid_runs = api.runs(
-        f"opentensor-dev/{pt.WANDB_PROJECT}",
+        f"opentensor-dev/{constants.WANDB_PROJECT}",
         filters={
             "config.type": "miner",
             "config.run_name": {"$regex": f"miner-{uid}-.*"},

--- a/tools/eval_all.py
+++ b/tools/eval_all.py
@@ -21,6 +21,7 @@ import random
 import argparse
 from tqdm import tqdm
 import bittensor as bt
+import constants
 import pretrain as pt
 from rich.table import Table
 from rich.console import Console
@@ -44,7 +45,7 @@ config = bt.config(parser)
 bt.logging(config=config)
 
 # Sync graph
-metagraph = bt.metagraph(pt.SUBNET_UID)
+metagraph = bt.metagraph(config.SUBNET_UID)
 
 uids = []
 timestamps = {}
@@ -62,7 +63,9 @@ pages = [
 ]
 batches = list(
     pt.dataset.SubsetFalconLoader(
-        batch_size=pt.batch_size, sequence_length=pt.sequence_length, pages=pages
+        batch_size=constants.batch_size,
+        sequence_length=constants.sequence_length,
+        pages=pages,
     )
 )
 

--- a/tools/upload_model.py
+++ b/tools/upload_model.py
@@ -1,0 +1,104 @@
+"""A script that pushes a model from disk to the subnet for evaluation.
+
+Usage:
+    python tools/upload_model.py --load_model_dir <path to model> --hf_repo_id my-username/my-project --wallet.name coldkey --wallet.hotkey hotkey
+    
+Prerequisites:
+   1. HF_ACCESS_TOKEN is set in the environment or .env file.
+   2. load_model_dir points to a directory containing a previously trained model, with relevant Hugging Face files (e.g. config.json).
+   3. Your miner is registered
+"""
+
+
+import asyncio
+import os
+import argparse
+import constants
+from model.storage.hugging_face.hugging_face_model_store import HuggingFaceModelStore
+import pretrain as pt
+import bittensor as bt
+
+from dotenv import load_dotenv
+
+load_dotenv()  # take environment variables from .env.
+
+os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+
+def get_config():
+    # Initialize an argument parser
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--hf_repo_id",
+        type=str,
+        help="The hugging face repo id, which should include the org or user and repo name. E.g. jdoe/pretraining",
+    )
+    parser.add_argument(
+        "--load_model_dir",
+        type=str,
+        default=None,
+        help="If provided, loads a previously trained HF model from the specified directory",
+    )
+    parser.add_argument(
+        "--netuid",
+        type=str,
+        default=constants.SUBNET_UID,
+        help="The subnet UID.",
+    )
+
+    # Include wallet and logging arguments from bittensor
+    bt.wallet.add_args(parser)
+    bt.subtensor.add_args(parser)
+    bt.logging.add_args(parser)
+
+    # Parse the arguments and create a configuration namespace
+    config = bt.config(parser)
+
+    return config
+
+
+def assert_registered(wallet: bt.wallet, metagraph: bt.metagraph, netuid: int) -> int:
+    """Asserts the wallet is a registered miner and returns the miner's UID.
+
+    Raises:
+        ValueError: If the wallet is not registered.
+    """
+    if wallet.hotkey.ss58_address not in metagraph.hotkeys:
+        raise ValueError(
+            f"You are not registered. \nUse: \n`btcli s register --netuid {netuid}` to register via burn \n or btcli s pow_register --netuid {netuid} to register with a proof of work"
+        )
+    uid = metagraph.hotkeys.index(wallet.hotkey.ss58_address)
+    bt.logging.success(
+        f"You are registered with address: {wallet.hotkey.ss58_address} and uid: {uid}"
+    )
+
+    return uid
+
+
+async def main(config: bt.config):
+    # Create bittensor objects.
+    bt.logging(config=config)
+
+    wallet = bt.wallet(config=config)
+    subtensor = bt.subtensor(config=config)
+    metagraph = subtensor.metagraph(config.netuid)
+
+    # Make sure we're registered and have a HuggingFace token.
+    assert_registered(wallet, metagraph, config.netuid)
+    HuggingFaceModelStore.assert_access_token_exists()
+
+    # Create the actions object.
+    actions = pt.mining.Actions.create(config, wallet, subtensor)
+
+    # Load the model from disk and push it to the chain and Hugging Face.
+    model = actions.load_local_model(config.load_model_dir)
+    await actions.push(model)
+
+
+if __name__ == "__main__":
+    # Parse and print configuration
+    config = get_config()
+    print(config)
+
+    asyncio.run(main(config))


### PR DESCRIPTION
1. Adds a tool to upload a previously trained model. This is useful if the training run crashes
2. Moves constants out of pretrain to avoid circular dependency issues (I also had to split out the test for the hugging face store for the same reason)