### PR TITLE
Perform a full eval after vali upgrade

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -4,6 +4,14 @@ from pathlib import Path
 # Project Constants.
 # ---------------------------------
 
+__version__ = "2.1.0"
+version_split = __version__.split(".")
+__spec_version__ = (
+    (1000 * int(version_split[0]))
+    + (10 * int(version_split[1]))
+    + (1 * int(version_split[2]))
+)
+
 # The validator WANDB project.
 WANDB_PROJECT = "pretraining-subnet"
 # The uid for this subnet.

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -259,7 +259,7 @@ async def main(config: bt.config):
                 "uid": my_uid,
                 "hotkey": wallet.hotkey.ss58_address,
                 "run_name": run_id,
-                "version": pt.__version__,
+                "version": constants.__version__,
                 "type": "miner",
             },
             allow_val_change=True,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -354,10 +354,11 @@ class Validator:
         bt.logging.info("Exiting update models loop.")
 
     def clean_models(self):
-        # Wait 5 minutes before starting the first clean-up loop to ensure the model tracker
-        # and model updater have had time to initialize.
-        time.sleep(dt.timedelta(minutes=5).total_seconds())
-        
+        # Delay the clean-up thread until the update loop has had time to run one full pass after an upgrade.
+        # This helps prevent unnecessarily deleting a model which is on disk, but hasn't yet been re-added to the
+        # model tracker by the update loop.
+        time.sleep(dt.timedelta(hours=1).total_seconds())
+
         # The below loop checks to clear out all models in local storage that are no longer referenced.
         while not self.stop_event.is_set():
             try:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -53,6 +53,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "true"
 class Validator:
     TRACKER_FILENAME = "model_tracker_2.pickle"
     UIDS_FILENAME = "uids_2.pickle"
+    VERSION_FILENAME = "version.txt"
 
     @staticmethod
     def config():
@@ -172,19 +173,42 @@ class Validator:
         # Setup a model tracker to track which miner is using which model id.
         self.model_tracker = ModelTracker()
 
-        # Load the state of the validator uids from file.
+        # Construct the filepaths to save/load state.
         self.uids_filepath = os.path.join(self.state_path(), Validator.UIDS_FILENAME)
+        self.tracker_filepath = os.path.join(
+            self.state_path(), Validator.TRACKER_FILENAME
+        )
+        version_filepath = os.path.join(self.state_path(), Validator.VERSION_FILENAME)
 
-        # Load the state of the tracker from file.
-        tracker_filepath = os.path.join(self.state_path(), Validator.TRACKER_FILENAME)
-        if not os.path.exists(tracker_filepath):
+        # Check if the version has changed since we last restarted.
+        previous_version = utils.get_version(version_filepath)
+        utils.save_version(version_filepath, constants.__spec_version__)
+
+        # If this is an upgrade, blow away state so that everything is re-evaluated.
+        if previous_version != constants.__spec_version__:
+            bt.logging.info(
+                f"Validator updated. Previous version={previous_version}. Current version={constants.__spec_version__}"
+            )
+            if os.path.exists(self.uids_filepath):
+                bt.logging.info(
+                    f"Because the validator updated, deleting {self.uids_filepath} so everything is re-evaluated."
+                )
+                os.remove(self.uids_filepath)
+            if os.path.exists(self.tracker_filepath):
+                bt.logging.info(
+                    f"Because the validator updated, deleting {self.tracker_filepath} so everything is re-evaluated."
+                )
+                os.remove(self.tracker_filepath)
+
+        # Initialize the model tracker.
+        if not os.path.exists(self.tracker_filepath):
             bt.logging.warning("No tracker state file found. Starting from scratch.")
         else:
-            self.model_tracker.load_state(tracker_filepath)
+            self.model_tracker.load_state(self.tracker_filepath)
 
+        # Initialize the UIDs to eval.
         if not os.path.exists(self.uids_filepath):
             bt.logging.warning("No uids state file found. Starting from scratch.")
-            # === Build initial uids to eval ===
             hotkeys = (
                 self.model_tracker.get_miner_hotkey_to_model_metadata_dict().keys()
             )
@@ -249,7 +273,7 @@ class Validator:
                 "uid": self.uid,
                 "hotkey": self.wallet.hotkey.ss58_address,
                 "run_name": run_id,
-                "version": pt.__version__,
+                "version": constants.__version__,
                 "type": "validator",
             },
             allow_val_change=True,
@@ -271,9 +295,7 @@ class Validator:
                 pickle.dump(self.pending_uids_to_eval, f)
 
         # Save the state of the tracker to file.
-        self.model_tracker.save_state(
-            os.path.join(self.state_path(), Validator.TRACKER_FILENAME)
-        )
+        self.model_tracker.save_state(self.tracker_filepath)
 
     def update_models(self):
         # Track how recently we updated each uid
@@ -332,6 +354,10 @@ class Validator:
         bt.logging.info("Exiting update models loop.")
 
     def clean_models(self):
+        # Wait 5 minutes before starting the first clean-up loop to ensure the model tracker
+        # and model updater have had time to initialize.
+        time.sleep(dt.timedelta(minutes=5).total_seconds())
+        
         # The below loop checks to clear out all models in local storage that are no longer referenced.
         while not self.stop_event.is_set():
             try:
@@ -402,6 +428,7 @@ class Validator:
         bt.logging.info("Synced metagraph")
         self.metagraph.load()
         self.miner_iterator.set_miner_uids(self.metagraph.uids.tolist())
+        self.model_tracker.on_hotkeys_updated(set(self.metagraph.hotkeys))
 
     async def try_run_step(self, ttl: int):
         async def _try_run_step():

--- a/pretrain/__init__.py
+++ b/pretrain/__init__.py
@@ -15,16 +15,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "2.1.0"
-
-
-version_split = __version__.split(".")
-__spec_version__ = (
-    (1000 * int(version_split[0]))
-    + (10 * int(version_split[1]))
-    + (1 * int(version_split[2]))
-)
-
 from . import dataset
 from . import graph
 from . import mining

--- a/tests/utilities/test_utils.py
+++ b/tests/utilities/test_utils.py
@@ -1,6 +1,8 @@
 import functools
+from tempfile import NamedTemporaryFile
 import time
 import unittest
+import constants
 
 from utilities.utils import run_in_subprocess
 from utilities import utils
@@ -75,6 +77,14 @@ class TestUtils(unittest.TestCase):
         namespace, name = utils.validate_hf_repo_id("my-org/my-repo-name")
         self.assertEqual("my-org", namespace)
         self.assertEqual("my-repo-name", name)
+
+    def test_save_and_load_version(self):
+        version = constants.__spec_version__
+        with NamedTemporaryFile() as f:
+            self.assertIsNone(utils.get_version(f.name))
+
+            utils.save_version(f.name, version)
+            self.assertEqual(utils.get_version(f.name), version)
 
 
 if __name__ == "__main__":

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -1,6 +1,7 @@
 import functools
 import multiprocessing
-from typing import Any, Tuple
+import os
+from typing import Any, Optional, Tuple
 import bittensor as bt
 
 from model.data import ModelId
@@ -92,3 +93,24 @@ def run_in_subprocess(func: functools.partial, ttl: int) -> Any:
         raise Exception(f"BaseException raised in subprocess: {str(result)}")
 
     return result
+
+
+def get_version(filepath: str) -> Optional[int]:
+    """Loads a version from the provided filepath or None if the file does not exist.
+
+    Args:
+        filepath (str): Path to the version file."""
+    if os.path.exists(filepath):
+        with open(filepath, "r") as f:
+            line = f.readline()
+            if line:
+                return int(line)
+            return None
+    return None
+
+
+def save_version(filepath: str, version: int):
+    """Saves a version to the provided filepath."""
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    with open(filepath, "w") as f:
+        f.write(str(version))


### PR DESCRIPTION
Add a check to the vali on start to detect a version upgrade.

Also delays the clean-up loop so that the update loop has a chance to perform a full iteration across miners to avoid deleting models from miners that are still registered.