### PR TITLE
Move state file to the model dir

### DIFF
--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -117,3 +117,16 @@ def save_version(filepath: str, version: int):
     os.makedirs(os.path.dirname(filepath), exist_ok=True)
     with open(filepath, "w") as f:
         f.write(str(version))
+
+
+def move_file_if_exists(src: str, dst: str) -> bool:
+    """Moves a file from src to dst if it exists.
+
+    Returns:
+        bool: True if the file was moved, False otherwise.
+    """
+    if os.path.exists(src) and not os.path.exists(dst):
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        os.replace(src, dst)
+        return True
+    return False


### PR DESCRIPTION
On a few occasions, valis have deleted the model store directory to free up space but didn't clean-up the vali-state files. This puts the vali in a bad state. 

In this change, we move the vali-state files inside the model-dir so they have a shared fate.