### PR TITLE
Add model parameter limits based on the block they were uploaded

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -29,8 +29,12 @@ SUBNET_UID = 9
 ROOT_DIR = Path(__file__).parent.parent
 # The maximum bytes for the hugging face repo (1 Gigabyte).
 MAX_HUGGING_FACE_BYTES = 1 * 1024 * 1024 * 1024
-# The maximum parameter size allowed for models.
-MAX_MODEL_PARAMETER_SIZE = 186_000_000
+# A mapping of block numbers to the max model size as of that block.
+# This dictionary must remain ordered by key.
+MAX_MODEL_PARAMETER_SIZES = [
+    (0, 186_000_000),
+    (2_405_920, 772_000_000),
+]
 # The number of run steps to log to single wandb run.
 MAX_RUN_STEPS_PER_WANDB_RUN = 100
 

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -27,8 +27,8 @@ WANDB_PROJECT = "pretraining-subnet"
 SUBNET_UID = 9
 # The root directory of this project.
 ROOT_DIR = Path(__file__).parent.parent
-# The maximum bytes for the hugging face repo (1 Gigabyte).
-MAX_HUGGING_FACE_BYTES = 1 * 1024 * 1024 * 1024
+# The maximum bytes for the hugging face repo (5 Gigabyte).
+MAX_HUGGING_FACE_BYTES = 5 * 1024 * 1024 * 1024
 # A mapping of block numbers to the max model size as of that block.
 # This dictionary must remain ordered by key.
 MAX_MODEL_PARAMETER_SIZES = [

--- a/model/model_updater.py
+++ b/model/model_updater.py
@@ -1,6 +1,7 @@
 import bittensor as bt
 from typing import Optional
 import constants
+from model import utils
 from model.data import ModelMetadata
 from model.model_tracker import ModelTracker
 from model.storage.local_model_store import LocalModelStore
@@ -66,9 +67,10 @@ class ModelUpdater:
 
         # Check that the parameter count of the model is within allowed bounds.
         parameter_size = sum(p.numel() for p in model.pt_model.parameters())
-        if parameter_size > constants.MAX_MODEL_PARAMETER_SIZE:
+        parameter_limit = utils.get_parameter_limit(metadata.block)
+        if parameter_size > parameter_limit:
             bt.logging.trace(
-                f"Sync for hotkey {hotkey} failed. Parameter size of the model {parameter_size} exceeded max size {constants.MAX_MODEL_PARAMETER_SIZE}."
+                f"Sync for hotkey {hotkey} failed. Parameter size of the model {parameter_size} exceeded max size {parameter_limit}."
             )
             return False
 

--- a/model/utils.py
+++ b/model/utils.py
@@ -1,0 +1,11 @@
+import constants
+
+
+def get_parameter_limit(block: int) -> int:
+    """Returns the maximum number of parameters allowed for a model at block."""
+    limit = None
+    for b, lim in constants.MAX_MODEL_PARAMETER_SIZES:
+        if block >= b:
+            limit = lim
+    assert limit is not None, f"No parameter limit found for block {block}"
+    return limit

--- a/tests/model/test_utils.py
+++ b/tests/model/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+
+from model.utils import get_parameter_limit
+
+
+class TestUtils:
+    @pytest.mark.parametrize(
+        ["block", "expected_limit"],
+        [
+            (0, 186_000_000),
+            (2_405_919, 186_000_000),
+            (2_405_920, 772_000_000),
+            (3_405_920, 772_000_000),
+        ],
+    )
+    def test_get_parameter_limit(self, block, expected_limit):
+        assert get_parameter_limit(block) == expected_limit
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Adds all necessary logic to support models of size 772M as of block 2,405,920.