### PR TITLE
Raise threshold for unreasonable output and keep models with weights.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*.ipynb
 
 # IPython
 profile_default/

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -730,14 +730,16 @@ class Validator:
         )
         self.weights = self.weights.nan_to_num(0.0)
 
-        # Filter based on win rate removing all by the sample_min best models for evaluation.
+        # Filter based on win rate removing all but the sample_min best models for evaluation.
         # First remove any models that have an infinite loss and 0 weight.
+        # Then override win rate for any model with weights to 1 to ensure they are included in the next run.
         filtered_win_rate = {
-            uid: wr
+            uid: (wr if self.weights[uid] == 0 else 1)
             for uid, wr in win_rate.items()
             if not all(math.isinf(x) for x in losses_per_uid.get(uid, [math.inf]))
             or self.weights[uid] > 0
         }
+
         self.uids_to_eval = set(
             sorted(filtered_win_rate, key=filtered_win_rate.get, reverse=True)[
                 : self.config.sample_min

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -732,12 +732,13 @@ class Validator:
 
         # Filter based on win rate removing all but the sample_min best models for evaluation.
         # First remove any models that have an infinite loss and 0 weight.
-        # Then override win rate for any model with weights to 1 to ensure they are included in the next run.
+        # Then override win rate for any model with weights to ensure they are included in the next run.
+        # Overrides are to 1 + weight to ensure that the best model is kept around first in case of all inf runs.
         filtered_win_rate = {
-            uid: (wr if self.weights[uid] == 0 else 1)
+            uid: (wr if self.weights[uid] == 0 else 1 + self.weights[uid].item())
             for uid, wr in win_rate.items()
             if not all(math.isinf(x) for x in losses_per_uid.get(uid, [math.inf]))
-            or self.weights[uid] > 0
+            or self.weights[uid].item() > 0
         }
 
         self.uids_to_eval = set(

--- a/pretrain/validation.py
+++ b/pretrain/validation.py
@@ -113,7 +113,7 @@ def check_for_reasonable_output(
     )[:, -output_length:]
 
     # Check if too many of the generated ids are the same between the two outputs.
-    if torch.sum(torch.eq(generate_id1s, generate_id2s)).item() >= output_length / 3:
+    if torch.sum(torch.eq(generate_id1s, generate_id2s)).item() >= output_length / 2:
         bt.logging.info(
             f"Model with config {model.config} had too much overlap between generated outputs."
         )
@@ -128,7 +128,7 @@ def check_for_reasonable_output(
         # Extract the count of the most common element
         most_common_count = counts[max_count_index].item()
 
-        if most_common_count > output_length / 3:
+        if most_common_count > output_length / 2:
             bt.logging.info(
                 f"Model with config {model.config} had too much repetition in generated output."
             )


### PR DESCRIPTION
Raise threshold for unreasonable output and keep models with weights.

This helps ensure the reasonable model check does not falsely penalize reasonable models.