### PR TITLE
Enable uploading a model with bfloat 16.

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -112,6 +112,7 @@ Some flags you may find useful:
 - `--load_uid`: when passing a uid you will download and train the model from the matching miner on the network.
 - `--load_model_dir`: the path to a local model directory [saved via Hugging Face API].
 - `--load_model`: the path to a safetensors file [not necessarily saved from Hugging Face API].
+- `--upload_b16`: if the model should be uploaded with bfloat16.
 
 ---
 
@@ -123,7 +124,7 @@ Due to rate limiting by the Bittensor chain you may only upload a model every 20
 
 You can manually upload with the following command:
 ```shell
-python scripts/upload_model.py --load_model_dir <path to model> --hf_repo_id my-username/my-project --wallet.name coldkey --wallet.hotkey hotkey
+python scripts/upload_model.py --load_model_dir <path to model> --upload_b16 --hf_repo_id my-username/my-project --wallet.name coldkey --wallet.hotkey hotkey
 ```
 
 ## Running a custom Miner
@@ -150,7 +151,7 @@ model: PreTrainedModel = await pt.mining.load_remote_model(uid=123, download_dir
 pt.mining.save(model, "model-foo/")
 
 # Load the model from disk.
-pt.mining.load_local_model("model-foo/")
+pt.mining.load_local_model("model-foo/", use_bf16=True)
 
 # Publish the model for validator evaluation.
 wallet = bt.wallet()

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -124,8 +124,10 @@ Due to rate limiting by the Bittensor chain you may only upload a model every 20
 
 You can manually upload with the following command:
 ```shell
-python scripts/upload_model.py --load_model_dir <path to model> --upload_b16 --hf_repo_id my-username/my-project --wallet.name coldkey --wallet.hotkey hotkey
+python scripts/upload_model.py --load_model_dir <path to model> --hf_repo_id my-username/my-project --wallet.name coldkey --wallet.hotkey hotkey
 ```
+
+Note: By default this will upload using bfloat16 (unlike the miner). You can pass ``--no-upload-b16`` to instead upload with fp32.
 
 ## Running a custom Miner
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -105,6 +105,11 @@ def get_config():
         help="If provided, loads a previously trained HF model from the specified directory",
     )
     parser.add_argument(
+        "--upload_b16",
+        action="store_true",  # Currently defaults to false. Flip post 7b block.
+        help="If provided, upload the model using bfloat16.",
+    )
+    parser.add_argument(
         "--load_model",
         type=str,
         default=None,
@@ -167,7 +172,11 @@ async def load_starting_model(
         # Get the best UID be incentive and load it.
         best_uid = pt.graph.best_uid(metagraph)
         model = await pt.mining.load_remote_model(
-            best_uid, config.model_dir, metagraph, metadata_store, remote_model_store
+            best_uid,
+            config.model_dir,
+            metagraph,
+            metadata_store,
+            remote_model_store,
         )
         bt.logging.success(
             f"Training with model from best uid: {best_uid}. Model={str(model)}"
@@ -371,8 +380,10 @@ async def main(config: bt.config):
                     f"Trained model had a best_avg_loss of {best_avg_loss} which is below the threshold of {config.avg_loss_upload_threshold}. Uploading to hugging face. "
                 )
 
-                # First, reload the best model from the training run.
-                model_to_upload = pt.mining.load_local_model(model_dir)
+                # First, reload the best model from the training run, using b16 if passed.
+                model_to_upload = pt.mining.load_local_model(
+                    model_dir, config.upload_b16
+                )
                 await pt.mining.push(
                     model_to_upload,
                     config.hf_repo_id,

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -107,7 +107,7 @@ def get_config():
     parser.add_argument(
         "--upload_b16",
         action="store_true",  # Currently defaults to false. Flip post 7b block.
-        help="If provided, upload the model using bfloat16.",
+        help="If true, upload the model using bfloat16.",
     )
     parser.add_argument(
         "--load_model",

--- a/pretrain/mining.py
+++ b/pretrain/mining.py
@@ -19,6 +19,7 @@
 import os
 import sys
 import time
+import torch
 from typing import Optional
 import constants
 from model.data import Model, ModelId
@@ -147,13 +148,21 @@ def load_gpt2_model(model_file: str) -> PreTrainedModel:
     return model
 
 
-def load_local_model(model_dir: str) -> PreTrainedModel:
+def load_local_model(model_dir: str, use_bf16: bool = False) -> PreTrainedModel:
     """Loads a model from a directory."""
-    return AutoModelForCausalLM.from_pretrained(
-        pretrained_model_name_or_path=model_dir,
-        local_files_only=True,
-        use_safetensors=True,
-    )
+    if use_bf16:
+        return AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path=model_dir,
+            local_files_only=True,
+            use_safetensors=True,
+            torch_dtype=torch.bfloat16,
+        )
+    else:
+        return AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path=model_dir,
+            local_files_only=True,
+            use_safetensors=True,
+        )
 
 
 async def load_best_model(download_dir: str):

--- a/scripts/upload_model.py
+++ b/scripts/upload_model.py
@@ -9,7 +9,6 @@ Prerequisites:
    3. Your miner is registered
 """
 
-
 import asyncio
 import os
 import argparse
@@ -42,6 +41,11 @@ def get_config():
         help="If provided, loads a previously trained HF model from the specified directory",
     )
     parser.add_argument(
+        "--upload_b16",
+        action="store_true",  # Currently defaults to false. Flip post 7b block.
+        help="If provided, upload the model using bfloat16.",
+    )
+    parser.add_argument(
         "--netuid",
         type=str,
         default=constants.SUBNET_UID,
@@ -72,7 +76,7 @@ async def main(config: bt.config):
     HuggingFaceModelStore.assert_access_token_exists()
 
     # Load the model from disk and push it to the chain and Hugging Face.
-    model = pt.mining.load_local_model(config.load_model_dir)
+    model = pt.mining.load_local_model(config.load_model_dir, config.upload_b16)
     await pt.mining.push(model, config.hf_repo_id, wallet)
 
 

--- a/scripts/upload_model.py
+++ b/scripts/upload_model.py
@@ -42,8 +42,8 @@ def get_config():
     )
     parser.add_argument(
         "--upload_b16",
-        action="store_true",  # Currently defaults to false. Flip post 7b block.
-        help="If provided, upload the model using bfloat16.",
+        action="store_false",  # Defaults to True.
+        help="If true, upload the model using bfloat16.",
     )
     parser.add_argument(
         "--netuid",


### PR DESCRIPTION
When the flag is passed, miners will do the final load_local_model call using bfloat16 to reduce the size before uploading to hugging face.

By default, from_pretrained from local files will upsample a bfloat16 model to fp32. This can double the size of the local model which would cause it to fail the validator 15 GB limit check. Note: when downloading this does not seem to occur.

Aside from the size limit, it does not matter how the model gets uploaded.
- Validators will download the model with the exact same code that miners use to generate the repo hash.
- Validators will load a model for inference from disk with bfloat16 and flash attention 2 regardless of what is in the repo.